### PR TITLE
bugfix/removed-counter-for-zoomskill

### DIFF
--- a/Cat Mafia/Assets/Scripts/ZoomSkill.cs
+++ b/Cat Mafia/Assets/Scripts/ZoomSkill.cs
@@ -13,7 +13,6 @@ public class CameraZoom : MonoBehaviour
     private float smoothTime = 0.25f;
 
     private bool isCooldown = false;
-    private float zoomCounter=0;
 
     [SerializeField] private Camera cam;
 
@@ -27,10 +26,7 @@ public class CameraZoom : MonoBehaviour
     {
         if (Input.GetKeyDown(KeyCode.D) && !isCooldown)
         {
-            if (zoomCounter != 2 ){
-                StartCoroutine(ZoomSkill());
-                zoomCounter+=1;
-            }
+            StartCoroutine(ZoomSkill());
         }
     }
 
@@ -50,7 +46,7 @@ public class CameraZoom : MonoBehaviour
         cam.orthographicSize = targetZoom;
 
         // Wait for 5 seconds
-        yield return new WaitForSeconds(5f);
+        yield return new WaitForSeconds(3f);
 
         // Return to original zoom
         while (Mathf.Abs(cam.orthographicSize - originalZoom) > 0.01f)


### PR DESCRIPTION
removed counter for zoom skill so that it has no limit and changed the cooldown from 5s to 3s but did not change 7s cooldown of skill

